### PR TITLE
Retain purchase originalJson, signature, userID for use in server-side receipt verification

### DIFF
--- a/SoomlaAndroidStore/src/com/soomla/store/SoomlaStore.java
+++ b/SoomlaAndroidStore/src/com/soomla/store/SoomlaStore.java
@@ -509,6 +509,7 @@ public class SoomlaStore {
         String orderId = purchase.getOrderId();
         String originalJson = purchase.getOriginalJson();
         String signature = purchase.getSignature();
+        String userId = purchase.getUserId();
 
         PurchasableVirtualItem pvi;
         try {
@@ -538,7 +539,7 @@ public class SoomlaStore {
                 }
 
                 BusProvider.getInstance().post(new MarketPurchaseEvent
-                        (pvi, developerPayload, token, orderId, originalJson, signature));
+                        (pvi, developerPayload, token, orderId, originalJson, signature, userId, null));
                 pvi.give(1);
                 BusProvider.getInstance().post(new ItemPurchasedEvent(pvi.getItemId(), developerPayload));
 

--- a/SoomlaAndroidStore/src/com/soomla/store/SoomlaStore.java
+++ b/SoomlaAndroidStore/src/com/soomla/store/SoomlaStore.java
@@ -507,6 +507,8 @@ public class SoomlaStore {
         String developerPayload = purchase.getDeveloperPayload();
         String token = purchase.getToken();
         String orderId = purchase.getOrderId();
+        String originalJson = purchase.getOriginalJson();
+        String signature = purchase.getSignature();
 
         PurchasableVirtualItem pvi;
         try {
@@ -536,7 +538,7 @@ public class SoomlaStore {
                 }
 
                 BusProvider.getInstance().post(new MarketPurchaseEvent
-                        (pvi, developerPayload, token, orderId));
+                        (pvi, developerPayload, token, orderId, originalJson, signature));
                 pvi.give(1);
                 BusProvider.getInstance().post(new ItemPurchasedEvent(pvi.getItemId(), developerPayload));
 

--- a/SoomlaAndroidStore/src/com/soomla/store/billing/IabPurchase.java
+++ b/SoomlaAndroidStore/src/com/soomla/store/billing/IabPurchase.java
@@ -33,13 +33,19 @@ public class IabPurchase {
     private String mToken;
     private String mOriginalJson;
     private String mSignature;
+    private String mUserId;
 
     public IabPurchase(String itemType, String sku, String purchaseToken, String orderId, int purchaseState) {
+        this(itemType, sku, purchaseToken, orderId, purchaseState, null);
+    }
+
+    public IabPurchase(String itemType, String sku, String purchaseToken, String orderId, int purchaseState, String userId) {
         mItemType = itemType;
         mSku = sku;
         mToken = purchaseToken;
         mOrderId = orderId;
         mPurchaseState = purchaseState;
+        mUserId = userId;
     }
 
     public IabPurchase(String itemType, String jsonPurchaseInfo, String signature) throws JSONException {
@@ -94,6 +100,10 @@ public class IabPurchase {
 
     public String getSignature() {
         return mSignature;
+    }
+
+    public String getUserId() {
+        return mUserId;
     }
 
     public void setDeveloperPayload(String developerPayload) {

--- a/SoomlaAndroidStore/src/com/soomla/store/events/MarketPurchaseEvent.java
+++ b/SoomlaAndroidStore/src/com/soomla/store/events/MarketPurchaseEvent.java
@@ -32,17 +32,19 @@ public class MarketPurchaseEvent extends SoomlaEvent {
      * @param token token associated with in-app billing purchase
      */
     public MarketPurchaseEvent(PurchasableVirtualItem purchasableVirtualItem, String payload,
-                               String token, String orderId) {
-        this(purchasableVirtualItem, payload, token, orderId, null);
+                               String token, String orderId, String originalJson, String signature) {
+        this(purchasableVirtualItem, payload, token, orderId, originalJson, signature, null);
     }
 
     public MarketPurchaseEvent(PurchasableVirtualItem purchasableVirtualItem, String payload,
-                               String token, String orderId, Object sender) {
+                               String token, String orderId, String originalJson, String signature, Object sender) {
         super(sender);
         mPurchasableVirtualItem = purchasableVirtualItem;
         mPayload = payload;
         mToken = token;
         mOrderId = orderId;
+        mOriginalJson = originalJson;
+        mSignature = signature;
     }
 
 
@@ -64,6 +66,14 @@ public class MarketPurchaseEvent extends SoomlaEvent {
         return mOrderId;
     }
 
+    public String getOriginalJson() {
+        return mOriginalJson;
+    }
+
+    public String getSignature() {
+        return mSignature;
+    }
+
     /** Private Members */
 
     private PurchasableVirtualItem mPurchasableVirtualItem;
@@ -73,4 +83,8 @@ public class MarketPurchaseEvent extends SoomlaEvent {
     private String mToken;
 
     private String mOrderId;
+
+    private String mOriginalJson;
+
+    private String mSignature;
 }

--- a/SoomlaAndroidStore/src/com/soomla/store/events/MarketPurchaseEvent.java
+++ b/SoomlaAndroidStore/src/com/soomla/store/events/MarketPurchaseEvent.java
@@ -37,6 +37,11 @@ public class MarketPurchaseEvent extends SoomlaEvent {
     }
 
     public MarketPurchaseEvent(PurchasableVirtualItem purchasableVirtualItem, String payload,
+                               String token, String orderId, Object sender) {
+        this(purchasableVirtualItem, payload, token, orderId, null, null, null, sender);
+    }
+
+    public MarketPurchaseEvent(PurchasableVirtualItem purchasableVirtualItem, String payload,
                                String token, String orderId, String originalJson, String signature, String userId, Object sender) {
         super(sender);
         mPurchasableVirtualItem = purchasableVirtualItem;

--- a/SoomlaAndroidStore/src/com/soomla/store/events/MarketPurchaseEvent.java
+++ b/SoomlaAndroidStore/src/com/soomla/store/events/MarketPurchaseEvent.java
@@ -32,12 +32,12 @@ public class MarketPurchaseEvent extends SoomlaEvent {
      * @param token token associated with in-app billing purchase
      */
     public MarketPurchaseEvent(PurchasableVirtualItem purchasableVirtualItem, String payload,
-                               String token, String orderId, String originalJson, String signature) {
-        this(purchasableVirtualItem, payload, token, orderId, originalJson, signature, null);
+                               String token, String orderId) {
+        this(purchasableVirtualItem, payload, token, orderId, null, null, null, null);
     }
 
     public MarketPurchaseEvent(PurchasableVirtualItem purchasableVirtualItem, String payload,
-                               String token, String orderId, String originalJson, String signature, Object sender) {
+                               String token, String orderId, String originalJson, String signature, String userId, Object sender) {
         super(sender);
         mPurchasableVirtualItem = purchasableVirtualItem;
         mPayload = payload;
@@ -45,6 +45,7 @@ public class MarketPurchaseEvent extends SoomlaEvent {
         mOrderId = orderId;
         mOriginalJson = originalJson;
         mSignature = signature;
+        mUserId = userId;
     }
 
 
@@ -74,6 +75,10 @@ public class MarketPurchaseEvent extends SoomlaEvent {
         return mSignature;
     }
 
+    public String getUserId() {
+        return mUserId;
+    }
+
     /** Private Members */
 
     private PurchasableVirtualItem mPurchasableVirtualItem;
@@ -87,4 +92,6 @@ public class MarketPurchaseEvent extends SoomlaEvent {
     private String mOriginalJson;
 
     private String mSignature;
+
+    private String mUserId;
 }


### PR DESCRIPTION
I want to be able to do my own server-side receipt verification; this requires the originalJson and signature fields from the IabPurchase object. This patch captures this data and makes it available in the MarketPurchaseEvent object. I submitted another pull request to get this data back to Unity here: https://github.com/soomla/unity3d-store/pull/422