### PR TITLE
Add OnVerificationStarted event to Android

### DIFF
--- a/SoomlaAndroidStore/src/com/soomla/store/SoomlaStore.java
+++ b/SoomlaAndroidStore/src/com/soomla/store/SoomlaStore.java
@@ -47,6 +47,7 @@ import com.soomla.store.events.RestoreTransactionsFinishedEvent;
 import com.soomla.store.events.RestoreTransactionsStartedEvent;
 import com.soomla.store.events.SoomlaStoreInitializedEvent;
 import com.soomla.store.events.UnexpectedStoreErrorEvent;
+import com.soomla.store.events.VerificationStartedEvent;
 import com.soomla.store.exceptions.VirtualItemNotFoundException;
 import com.soomla.store.purchaseTypes.PurchaseWithMarket;
 
@@ -205,6 +206,11 @@ public class SoomlaStore {
                             public void fail(String message) {
                                 BusProvider.getInstance().post(new RestoreTransactionsFinishedEvent(false));
                                 handleErrorResult(UnexpectedStoreErrorEvent.ErrorCode.GENERAL, message);
+                            }
+
+                            @Override
+                            public void verificationStarted(List<IabPurchase> purchases) {
+                                handleVerificationStarted(purchases);
                             }
                         };
 
@@ -431,6 +437,11 @@ public class SoomlaStore {
                                     public void fail(String message) {
                                         handleErrorResult(UnexpectedStoreErrorEvent.ErrorCode.PURCHASE_FAIL, message);
                                     }
+
+                                    @Override
+                                    public void verificationStarted(List<IabPurchase> purchases) {
+                                        handleVerificationStarted(purchases);
+                                    }
                                 };
 
                         BusProvider.getInstance().post(new MarketPurchaseStartedEvent(pvi, getInAppBillingService().shouldVerifyPurchases()));
@@ -599,6 +610,27 @@ public class SoomlaStore {
                     + "VirtualCurrencyPack OR MarketItem  with productId: " + sku
                     + ". It's unexpected so an unexpected error is being emitted.");
             BusProvider.getInstance().post(new UnexpectedStoreErrorEvent());
+        }
+    }
+
+    /**
+     * Posts an event about the start of verification for the purchase, or an unexpected
+     * error event if the item was not found.
+     *
+     * @param purchases List of purchases to handle.
+     */
+    private void handleVerificationStarted(List<IabPurchase> purchases) {
+        for (IabPurchase purchase : purchases) {
+            String sku = purchase.getSku();
+            try {
+                PurchasableVirtualItem v = StoreInfo.getPurchasableItem(sku);
+                BusProvider.getInstance().post(new VerificationStartedEvent(v));
+            } catch (VirtualItemNotFoundException e) {
+                SoomlaUtils.LogError(TAG, "(purchaseActionResultCancelled) ERROR : Couldn't find the "
+                        + "VirtualCurrencyPack OR MarketItem  with productId: " + sku
+                        + ". It's unexpected so an unexpected error is being emitted.");
+                BusProvider.getInstance().post(new UnexpectedStoreErrorEvent());
+            }
         }
     }
 

--- a/SoomlaAndroidStore/src/com/soomla/store/billing/IabCallbacks.java
+++ b/SoomlaAndroidStore/src/com/soomla/store/billing/IabCallbacks.java
@@ -76,6 +76,14 @@ public class IabCallbacks {
           * @param message reason for failure
           */
         public void fail(String message);
+
+         /**
+          * The purchase verification has started
+          *
+          * @param purchase the purchase being verified
+          */
+         public void verificationStarted(List<IabPurchase> purchases);
+
     }
 
      /**
@@ -96,6 +104,13 @@ public class IabCallbacks {
           * @param message reason for failure
           */
         public void fail(String message);
+
+         /**
+          * The purchase verification has started
+          *
+          * @param purchase the purchase being verified
+          */
+         public void verificationStarted(List<IabPurchase> purchases);
     }
 
      /**

--- a/SoomlaAndroidStore/src/com/soomla/store/events/VerificationStartedEvent.java
+++ b/SoomlaAndroidStore/src/com/soomla/store/events/VerificationStartedEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2012-2014 Soomla Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.soomla.store.events;
+
+import com.soomla.events.SoomlaEvent;
+import com.soomla.store.domain.PurchasableVirtualItem;
+
+/**
+ * This event is fired when a Market purchase's verification is started
+ */
+public class VerificationStartedEvent extends SoomlaEvent {
+
+    /**
+     * Constructor
+     *
+     * @param purchasableVirtualItem
+     */
+    public VerificationStartedEvent(PurchasableVirtualItem purchasableVirtualItem) {
+        this(purchasableVirtualItem, null);
+    }
+
+    public VerificationStartedEvent(PurchasableVirtualItem purchasableVirtualItem, Object sender) {
+        super(sender);
+        mPurchasableVirtualItem = purchasableVirtualItem;
+    }
+
+
+    /** Setters and Getters */
+
+    public PurchasableVirtualItem getPurchasableVirtualItem() {
+        return mPurchasableVirtualItem;
+    }
+
+
+    /** Private Members */
+
+    private PurchasableVirtualItem mPurchasableVirtualItem;
+}


### PR DESCRIPTION
Create the new VerificationStarted event
Define a verificationStarted method on both the Purchase and Restore listener interfaces so the verification can be triggered deeper in the call stack
Add posting the VerificationStarted event to the Bus

This is one part of a multi-repository checkin
Unity store android change PR: https://github.com/soomla/unity3d-store/pull/498
Google play android change PR: https://github.com/soomla/android-store-google-play/pull/18